### PR TITLE
Switch away from deprecated setup-android

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,6 @@ jobs:
         }" >> meetupapi/src/main/java/com/gdgistanbul/api/Secrets.kt
 #     - name: print Secrets.kt
 #       run: tail meetupapi/src/main/java/com/gdgistanbul/api/Secrets.kt
-    - name: setup-android
-      uses: msfjarvis/setup-android@0.2
+    - name: Build
+      run: ./gradlew assembleDebug
 


### PR DESCRIPTION
I am in the process of deprecating setup-android as GitHub Actions now ships default containers with everything that's needed.
﻿